### PR TITLE
fix compilation error: invalid conversion from int* to uint*

### DIFF
--- a/generic poll server/generic_poll_server.c
+++ b/generic poll server/generic_poll_server.c
@@ -708,7 +708,7 @@ static bool generic_poll_server_start(int poll_timeout)
             {
                 unsigned long piko = 1;
                 ioctlsocket(new_socket, FIONBIO, &piko);
-                int addrlen = sizeof(new_client);
+                unsigned int addrlen = sizeof(new_client);
                 getpeername(new_socket, (struct sockaddr *)&new_client, &addrlen);
                 char str[INET6_ADDRSTRLEN];
                 if (inet_ntop(AF_INET6, &new_client.sin6_addr, str, sizeof(str))) {


### PR DESCRIPTION
should address the -fpermissive compilation error (gcc 11.4.0)