### PR TITLE
Fixed compilation errors on Linux.

### DIFF
--- a/generic poll server/generic_poll_server.c
+++ b/generic poll server/generic_poll_server.c
@@ -708,8 +708,13 @@ static bool generic_poll_server_start(int poll_timeout)
             {
                 unsigned long piko = 1;
                 ioctlsocket(new_socket, FIONBIO, &piko);
+#ifdef __WIN32__
                 int addrlen = sizeof(new_client);
                 getpeername(new_socket, (struct sockaddr *)&new_client, &addrlen);
+#else
+                socklen_t addrlen = sizeof(new_client);
+                getpeername(new_socket, (struct sockaddr *)&new_client, &addrlen);
+#endif
                 char str[INET6_ADDRSTRLEN];
                 if (inet_ntop(AF_INET6, &new_client.sin6_addr, str, sizeof(str))) {
                     s_debug("Client address is %s : %d\n", str, ntohs(new_client.sin6_port));

--- a/generic poll server/generic_poll_server.h
+++ b/generic poll server/generic_poll_server.h
@@ -7,6 +7,13 @@
 #include "emulator_network_access_defines.h"
 
 
+#if (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__)))
+typedef int SOCKET;
+typedef struct sockaddr_in SOCKADDR_IN;
+typedef struct sockaddr SOCKADDR;
+typedef struct in_addr IN_ADDR;
+#endif
+
 /*
 The function doing the command must returns this :
     0 for regular command


### PR DESCRIPTION
I fixed some errors I encountered while compiling snes9x-emunwa on Linux.
I did not test this yet with Bsnes-plus, but I'm guessing they would have the same error if type `SOCKET` has never been defined for *nix.

I also did the following on the main branch `snes9x-nwaccess`:

```
--- a/emu-nwaccess/snes9x-nwaccess.cpp
+++ b/emu-nwaccess/snes9x-nwaccess.cpp
@@ -33,10 +33,6 @@
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR -1
 #define closesocket(s) close(s)
-typedef int SOCKET;
-typedef struct sockaddr_in SOCKADDR_IN;
-typedef struct sockaddr SOCKADDR;
-typedef struct in_addr IN_ADDR;
```